### PR TITLE
IPad UI fixes

### DIFF
--- a/Miracle Messages.xcodeproj/project.pbxproj
+++ b/Miracle Messages.xcodeproj/project.pbxproj
@@ -821,7 +821,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BASE_URL = "https://my.miraclemessages.org";
 				CODE_SIGN_ENTITLEMENTS = MiracleMessages/MiracleMsg.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEVELOPMENT_TEAM = GE8VHP39HG;
 				FIREBASE = "GoogleService-Info";
 				FIREBASE_SERVICES_FILENAME = "GoogleService-Info";
@@ -830,8 +830,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.winraguini.MiracleMessages;
 				PRODUCT_NAME = MiracleMsg;
-				PROVISIONING_PROFILE = "b3a6b4e8-cc2d-43ba-857c-f6da0eeb1dd2";
-				PROVISIONING_PROFILE_SPECIFIER = miraclemessages.dev;
+				PROVISIONING_PROFILE = "8142957a-7f00-46c4-838e-6473bf0931cd";
+				PROVISIONING_PROFILE_SPECIFIER = miraclemessages.dist;
 				REGISTER_URL = "https://my.miraclemessages.org/#!/register";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/MiracleMessages/Base.lproj/Main.storyboard
+++ b/MiracleMessages/Base.lproj/Main.storyboard
@@ -5,7 +5,7 @@
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -51,15 +51,16 @@
                                     <constraint firstAttribute="height" constant="71" id="TNx-du-S11"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You'll need a Google account before creating your profile" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LmM-kp-l28">
-                                <rect key="frame" x="16" y="172" width="343" height="51.5"/>
-                                <fontDescription key="fontDescription" name="ArialMT" family="Arial" pointSize="23"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="You'll need a Google account before creating your profile" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="LmM-kp-l28">
+                                <rect key="frame" x="16" y="172" width="343" height="114"/>
+                                <fontDescription key="fontDescription" name="ArialMT" family="Arial" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="Akv-6c-8sh" firstAttribute="top" relation="greaterThanOrEqual" secondItem="LmM-kp-l28" secondAttribute="bottom" constant="10" id="3e9-sN-KK4"/>
                             <constraint firstItem="LmM-kp-l28" firstAttribute="top" secondItem="uxr-g0-asb" secondAttribute="bottom" constant="50" id="BFA-gN-seR"/>
                             <constraint firstAttribute="trailing" secondItem="Akv-6c-8sh" secondAttribute="trailing" constant="16" id="BfM-dK-pHs"/>
                             <constraint firstItem="Akv-6c-8sh" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="GMs-bV-k2q"/>

--- a/MiracleMessages/Base.lproj/Main.storyboard
+++ b/MiracleMessages/Base.lproj/Main.storyboard
@@ -398,6 +398,8 @@
 a.) your video may be made public and shared widely;
 b.) we don't know how your loved one(s) will respond, if at all; and
 c.) we don't know if we'll be able to find your loved one(s).
+                                </mutableString>
+
                                 <fontDescription key="fontDescription" name="ArialMT" family="Arial" pointSize="20"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/MiracleMessages/Base.lproj/Main.storyboard
+++ b/MiracleMessages/Base.lproj/Main.storyboard
@@ -32,7 +32,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uxr-g0-asb">
-                                <rect key="frame" x="16" y="81" width="343" height="41"/>
+                                <rect key="frame" x="16" y="85" width="343" height="41"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
@@ -310,7 +310,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ready to record a message?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1L3-MF-TRz">
-                                <rect key="frame" x="18" y="143.5" width="328" height="92"/>
+                                <rect key="frame" x="18" y="147.5" width="328" height="92"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="328" id="2dh-Wt-jLt"/>
                                     <constraint firstAttribute="height" constant="92" id="rav-cb-N3v"/>
@@ -320,7 +320,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hi," lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4sO-gu-4o4" userLabel="Hello Label">
-                                <rect key="frame" x="18" y="101" width="339" height="42.5"/>
+                                <rect key="frame" x="18" y="105" width="339" height="42.5"/>
                                 <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="38"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -375,7 +375,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Before we start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="GS4-Ok-gU7">
-                                <rect key="frame" x="18" y="57" width="339" height="45"/>
+                                <rect key="frame" x="18" y="105" width="339" height="45"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="mAY-lW-l7x"/>
                                 </constraints>
@@ -384,7 +384,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A script to guide you" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gb1-KC-2gE">
-                                <rect key="frame" x="18" y="102" width="339" height="20"/>
+                                <rect key="frame" x="18" y="150" width="339" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="SWA-UG-tqC"/>
                                 </constraints>
@@ -393,7 +393,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s70-JI-P1t">
-                                <rect key="frame" x="16" y="142" width="343" height="444"/>
+                                <rect key="frame" x="16" y="190" width="343" height="396"/>
                                 <string key="text">We would be happy to help you record a short video message to your loved one(s) and attempt to deliver it! Please be aware that, by recording a video message with us, you acknowledge that:
 a.) your video may be made public and shared widely;
 b.) we don't know how your loved one(s) will respond, if at all; and
@@ -463,7 +463,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated May 18, 2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MZT-Vt-3I2">
-                                <rect key="frame" x="16" y="169" width="343" height="20"/>
+                                <rect key="frame" x="16" y="217" width="343" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="Ygz-NU-mUQ"/>
                                 </constraints>
@@ -472,7 +472,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 <nil key="highlightedColor"/>
                             </label>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="55o-Fe-56t">
-                                <rect key="frame" x="0.0" y="197" width="375" height="470"/>
+                                <rect key="frame" x="0.0" y="245" width="375" height="422"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6jR-qY-Ejq" userLabel="Content View">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="526"/>
@@ -577,13 +577,13 @@ c.) we don't know if we'll be able to find your loved one(s).
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Miracle Messages Consent and Release" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="zUi-yh-dyO">
-                                <rect key="frame" x="16" y="49" width="343" height="74"/>
+                                <rect key="frame" x="16" y="97" width="343" height="74"/>
                                 <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="33"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated May 18, 2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CLo-LS-gC8">
-                                <rect key="frame" x="16" y="131" width="343" height="20"/>
+                                <rect key="frame" x="16" y="179" width="343" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="BH1-Qq-JJO"/>
                                 </constraints>
@@ -592,7 +592,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1ir-qq-vHG" customClass="YPDrawSignatureView" customModule="Dev_MiracleMsg" customModuleProvider="target">
-                                <rect key="frame" x="16" y="209" width="343" height="389"/>
+                                <rect key="frame" x="16" y="257" width="343" height="341"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="strokeWidth">
@@ -604,7 +604,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bKu-E4-YxG">
-                                <rect key="frame" x="287" y="163" width="56" height="37"/>
+                                <rect key="frame" x="287" y="211" width="56" height="37"/>
                                 <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="22"/>
                                 <state key="normal" title="Clear"/>
                                 <connections>
@@ -612,7 +612,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign below" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yfc-tt-GOr">
-                                <rect key="frame" x="16" y="169" width="121.5" height="26"/>
+                                <rect key="frame" x="16" y="217" width="121.5" height="26"/>
                                 <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="23"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -2811,7 +2811,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a0M-VO-Tuz">
-                                <rect key="frame" x="18" y="87" width="339" height="45"/>
+                                <rect key="frame" x="18" y="91" width="339" height="45"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="1Tc-Kb-pOL"/>
                                 </constraints>
@@ -2820,7 +2820,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Everything look good?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Sm-UV-6GI">
-                                <rect key="frame" x="18" y="132" width="339" height="21"/>
+                                <rect key="frame" x="18" y="136" width="339" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="ghv-qa-p67"/>
                                 </constraints>
@@ -2829,7 +2829,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Click the 'Submit' button below to upload to our database." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LjX-V3-7h1" customClass="VerticalAlignLabel" customModule="Dev_MiracleMsg" customModuleProvider="target">
-                                <rect key="frame" x="18" y="181" width="339" height="49.5"/>
+                                <rect key="frame" x="18" y="185" width="339" height="49.5"/>
                                 <fontDescription key="fontDescription" name="ArialMT" family="Arial" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -2851,7 +2851,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OR" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tJl-d9-UYN">
-                                <rect key="frame" x="16" y="255.5" width="343" height="35"/>
+                                <rect key="frame" x="16" y="259.5" width="343" height="35"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="3a5-y9-UZ3"/>
                                 </constraints>
@@ -2859,8 +2859,8 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Click back to retake the video." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cag-V1-dMo">
-                                <rect key="frame" x="16" y="315.5" width="343" height="60"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Click back to retake the video." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cag-V1-dMo">
+                                <rect key="frame" x="16" y="319.5" width="343" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="fdE-Xx-Qcq"/>
                                 </constraints>
@@ -3017,7 +3017,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="dWw-pP-c7m" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="IWY-n4-2Ql">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="48"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -3035,7 +3035,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="ogM-Iq-pBO" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="YFz-NS-V3N">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="48"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -3053,7 +3053,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="jwM-YW-5It" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="LsH-oK-gA2">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="48"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -3071,7 +3071,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="vKY-Sm-hXB" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="iGE-YI-cuE">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="48"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/MiracleMessages/Base.lproj/Main.storyboard
+++ b/MiracleMessages/Base.lproj/Main.storyboard
@@ -310,18 +310,18 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ready to record a message?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1L3-MF-TRz">
-                                <rect key="frame" x="18" y="145" width="328" height="92"/>
+                                <rect key="frame" x="18" y="143.5" width="328" height="92"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="328" id="2dh-Wt-jLt"/>
                                     <constraint firstAttribute="height" constant="92" id="rav-cb-N3v"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="39"/>
+                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="38"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hi," lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4sO-gu-4o4" userLabel="Hello Label">
-                                <rect key="frame" x="18" y="101" width="339" height="44"/>
-                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="39"/>
+                                <rect key="frame" x="18" y="101" width="339" height="42.5"/>
+                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="38"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -345,6 +345,8 @@
                             <constraint firstAttribute="trailing" secondItem="4sO-gu-4o4" secondAttribute="trailing" constant="18" id="5jh-6P-ueV"/>
                             <constraint firstItem="4Lk-OK-F7L" firstAttribute="top" secondItem="cW5-BT-YtL" secondAttribute="bottom" constant="16" id="HPH-DJ-Irl"/>
                             <constraint firstItem="4sO-gu-4o4" firstAttribute="leading" secondItem="ek2-xR-gxY" secondAttribute="leading" constant="18" id="TW5-vY-BUu"/>
+                            <constraint firstItem="cW5-BT-YtL" firstAttribute="leading" secondItem="ek2-xR-gxY" secondAttribute="leading" constant="13" id="TX0-tD-98G"/>
+                            <constraint firstAttribute="trailing" secondItem="cW5-BT-YtL" secondAttribute="trailing" constant="13" id="hvI-WL-pJe"/>
                             <constraint firstItem="cW5-BT-YtL" firstAttribute="centerX" secondItem="ek2-xR-gxY" secondAttribute="centerX" id="j5D-f2-ijU"/>
                             <constraint firstItem="1L3-MF-TRz" firstAttribute="leading" secondItem="ek2-xR-gxY" secondAttribute="leading" constant="18" id="qfF-w4-r2Y"/>
                             <constraint firstItem="4sO-gu-4o4" firstAttribute="top" secondItem="A2H-76-3am" secondAttribute="bottom" constant="37" id="s2s-lb-CQ2"/>
@@ -372,17 +374,17 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Before we start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GS4-Ok-gU7">
-                                <rect key="frame" x="18" y="101" width="339" height="45"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Before we start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="GS4-Ok-gU7">
+                                <rect key="frame" x="18" y="57" width="339" height="45"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="mAY-lW-l7x"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="39"/>
+                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="38"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A script to guide you" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gb1-KC-2gE">
-                                <rect key="frame" x="18" y="146" width="339" height="20"/>
+                                <rect key="frame" x="18" y="102" width="339" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="SWA-UG-tqC"/>
                                 </constraints>
@@ -390,9 +392,12 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s70-JI-P1t">
-                                <rect key="frame" x="16" y="186" width="343" height="335.5"/>
-                                <string key="text">We would be happy to help you record a short video message to your loved one(s) and attempt to deliver it! Please be aware that, by recording a video message withus, you acknowledge that: a.) your video may be made public and shared widely; b.) we don't know how your loved one(s) will respond, if at all; and c.) we don't know if we'll be able to find your loved one(s). The only guarantee is that this is an opportunity for you to record a video message to someone you love, and that we will try to deliver it. If you agree, please read and sign this form!</string>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s70-JI-P1t">
+                                <rect key="frame" x="16" y="142" width="343" height="444"/>
+                                <mutableString key="text">We would be happy to help you record a short video message to your loved one(s) and attempt to deliver it! Please be aware that, by recording a video message with us, you acknowledge that:
+a.) your video may be made public and shared widely;
+b.) we don't know how your loved one(s) will respond, if at all; and
+c.) we don't know if we'll be able to find your loved one(s).
                                 <fontDescription key="fontDescription" name="ArialMT" family="Arial" pointSize="20"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -418,13 +423,16 @@
                             <constraint firstAttribute="trailing" secondItem="s70-JI-P1t" secondAttribute="trailing" constant="16" id="7ud-1i-Vjt"/>
                             <constraint firstItem="GS4-Ok-gU7" firstAttribute="leading" secondItem="Kqr-b4-8fb" secondAttribute="leading" constant="18" id="FDZ-dT-bTc"/>
                             <constraint firstItem="Gb1-KC-2gE" firstAttribute="leading" secondItem="GS4-Ok-gU7" secondAttribute="leading" id="GLU-rt-8p3"/>
+                            <constraint firstItem="GUQ-5d-4ze" firstAttribute="top" secondItem="s70-JI-P1t" secondAttribute="bottom" constant="8" id="JTK-6G-4QE"/>
                             <constraint firstItem="s70-JI-P1t" firstAttribute="leading" secondItem="Kqr-b4-8fb" secondAttribute="leading" constant="16" id="b9l-Ym-dO0"/>
+                            <constraint firstItem="GUQ-5d-4ze" firstAttribute="leading" secondItem="Kqr-b4-8fb" secondAttribute="leading" constant="13" id="cRu-aa-nAK"/>
                             <constraint firstAttribute="trailing" secondItem="GS4-Ok-gU7" secondAttribute="trailing" constant="18" id="fNg-72-N0a"/>
                             <constraint firstItem="s70-JI-P1t" firstAttribute="top" secondItem="Gb1-KC-2gE" secondAttribute="bottom" constant="20" id="hKx-kR-gUV"/>
                             <constraint firstItem="Gb1-KC-2gE" firstAttribute="top" secondItem="GS4-Ok-gU7" secondAttribute="bottom" id="hMp-p2-0hg"/>
                             <constraint firstItem="Gb1-KC-2gE" firstAttribute="trailing" secondItem="GS4-Ok-gU7" secondAttribute="trailing" id="jym-0c-Yrx"/>
                             <constraint firstItem="GS4-Ok-gU7" firstAttribute="top" secondItem="GZk-7A-xuk" secondAttribute="bottom" constant="37" id="ppQ-Yi-wxR"/>
                             <constraint firstItem="GUQ-5d-4ze" firstAttribute="centerX" secondItem="Kqr-b4-8fb" secondAttribute="centerX" id="tKD-eK-00Y"/>
+                            <constraint firstAttribute="trailing" secondItem="GUQ-5d-4ze" secondAttribute="trailing" constant="13" id="zgP-ap-21I"/>
                         </constraints>
                     </view>
                     <connections>
@@ -447,14 +455,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Miracle Messages Consent and Release" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vsg-a2-18h">
-                                <rect key="frame" x="16" y="101" width="343" height="131"/>
-                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="39"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Miracle Messages Consent and Release" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="vsg-a2-18h">
+                                <rect key="frame" x="16" y="101" width="343" height="104"/>
+                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="33"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated May 18, 2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MZT-Vt-3I2">
-                                <rect key="frame" x="16" y="240" width="343" height="20"/>
+                                <rect key="frame" x="16" y="169" width="343" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="Ygz-NU-mUQ"/>
                                 </constraints>
@@ -463,10 +471,10 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="55o-Fe-56t">
-                                <rect key="frame" x="0.0" y="268" width="375" height="399"/>
+                                <rect key="frame" x="0.0" y="197" width="375" height="470"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6jR-qY-Ejq" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="527"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="526"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nje-3N-oCA">
                                                 <rect key="frame" x="16" y="16" width="343" height="183"/>
@@ -496,9 +504,9 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTK-cy-m5s">
-                                                <rect key="frame" x="16" y="471" width="343" height="36"/>
-                                                <fontDescription key="fontDescription" name="ArialMT" family="Arial" pointSize="21"/>
+                                            <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTK-cy-m5s">
+                                                <rect key="frame" x="16" y="471" width="343" height="35"/>
+                                                <fontDescription key="fontDescription" name="ArialMT" family="Arial" pointSize="20"/>
                                                 <state key="normal" title="I have read the above consent."/>
                                                 <connections>
                                                     <segue destination="V3p-aX-g7j" kind="show" id="oij-uW-SGV"/>
@@ -539,7 +547,7 @@
                         <constraints>
                             <constraint firstItem="MZT-Vt-3I2" firstAttribute="leading" secondItem="v7l-lT-L7d" secondAttribute="leading" constant="16" id="1UR-kP-Bzu"/>
                             <constraint firstAttribute="trailing" secondItem="MZT-Vt-3I2" secondAttribute="trailing" constant="16" id="2TK-WW-AHE"/>
-                            <constraint firstItem="MZT-Vt-3I2" firstAttribute="top" secondItem="vsg-a2-18h" secondAttribute="bottom" constant="8" id="FiB-iE-ONp"/>
+                            <constraint firstItem="MZT-Vt-3I2" firstAttribute="top" secondItem="vsg-a2-18h" secondAttribute="bottom" constant="38" id="FiB-iE-ONp"/>
                             <constraint firstAttribute="bottom" secondItem="55o-Fe-56t" secondAttribute="bottom" id="IUt-gQ-egQ"/>
                             <constraint firstItem="vsg-a2-18h" firstAttribute="top" secondItem="Mxd-UR-a7Y" secondAttribute="bottom" constant="37" id="SJg-qN-fZ1"/>
                             <constraint firstItem="6jR-qY-Ejq" firstAttribute="width" secondItem="v7l-lT-L7d" secondAttribute="width" id="Sa9-Tc-PPu"/>
@@ -567,14 +575,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Miracle Messages Consent and Release" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zUi-yh-dyO">
-                                <rect key="frame" x="16" y="93" width="343" height="131"/>
-                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="39"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Miracle Messages Consent and Release" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="zUi-yh-dyO">
+                                <rect key="frame" x="16" y="49" width="343" height="74"/>
+                                <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="33"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated May 18, 2017" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CLo-LS-gC8">
-                                <rect key="frame" x="16" y="232" width="343" height="20"/>
+                                <rect key="frame" x="16" y="131" width="343" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="BH1-Qq-JJO"/>
                                 </constraints>
@@ -583,7 +591,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1ir-qq-vHG" customClass="YPDrawSignatureView" customModule="Dev_MiracleMsg" customModuleProvider="target">
-                                <rect key="frame" x="16" y="310" width="343" height="288"/>
+                                <rect key="frame" x="16" y="209" width="343" height="389"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="strokeWidth">
@@ -595,7 +603,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bKu-E4-YxG">
-                                <rect key="frame" x="287" y="264" width="56" height="37"/>
+                                <rect key="frame" x="287" y="163" width="56" height="37"/>
                                 <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="22"/>
                                 <state key="normal" title="Clear"/>
                                 <connections>
@@ -603,7 +611,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign below" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yfc-tt-GOr">
-                                <rect key="frame" x="16" y="270" width="121.5" height="26"/>
+                                <rect key="frame" x="16" y="169" width="121.5" height="26"/>
                                 <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="23"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -837,7 +845,7 @@
                                                             <constraint firstAttribute="height" constant="1" id="U7x-nl-vHb"/>
                                                         </constraints>
                                                     </view>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How long have you been on and off the streets? *" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1v-CE-OS3" userLabel="Years on-and-off the street label">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How long have you been on and off the streets? *" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="E1v-CE-OS3" userLabel="Years on-and-off the street label">
                                                         <rect key="frame" x="18" y="781" width="339" height="15"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="15" id="qR9-3n-nMD"/>
@@ -1159,7 +1167,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C2S-tX-Ghs">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="C2S-tX-Ghs">
                                                         <rect key="frame" x="18" y="868" width="339" height="120"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="120" id="xGi-qp-ZEW"/>
@@ -1410,11 +1418,13 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="qB0-Ds-fFu" secondAttribute="trailing" id="0ao-0X-bQ3"/>
+                            <constraint firstItem="Jqf-MO-d9t" firstAttribute="leading" secondItem="WNJ-jO-tPB" secondAttribute="leading" constant="13" id="DsU-8j-O0r"/>
                             <constraint firstItem="Jqf-MO-d9t" firstAttribute="top" secondItem="qB0-Ds-fFu" secondAttribute="bottom" constant="30" id="Jfa-Jc-8zl"/>
                             <constraint firstItem="4ru-iM-cMU" firstAttribute="top" secondItem="Jqf-MO-d9t" secondAttribute="bottom" constant="16" id="Zc6-gi-lLT"/>
                             <constraint firstItem="Jqf-MO-d9t" firstAttribute="centerX" secondItem="WNJ-jO-tPB" secondAttribute="centerX" id="doL-CU-lyX"/>
                             <constraint firstItem="qB0-Ds-fFu" firstAttribute="leading" secondItem="WNJ-jO-tPB" secondAttribute="leading" id="fDy-Sp-plA"/>
                             <constraint firstItem="G0Y-Av-8IP" firstAttribute="width" secondItem="WNJ-jO-tPB" secondAttribute="width" id="hVn-g5-8HA"/>
+                            <constraint firstAttribute="trailing" secondItem="Jqf-MO-d9t" secondAttribute="trailing" constant="13" id="nOR-EK-fod"/>
                             <constraint firstItem="qB0-Ds-fFu" firstAttribute="top" secondItem="WNJ-jO-tPB" secondAttribute="top" id="xLS-E7-G6k"/>
                         </constraints>
                     </view>
@@ -1949,11 +1959,13 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="gfp-3L-IYu" firstAttribute="leading" secondItem="H7h-mE-sVf" secondAttribute="leading" id="1fO-0H-JG1"/>
+                            <constraint firstItem="GWG-05-XRf" firstAttribute="leading" secondItem="H7h-mE-sVf" secondAttribute="leading" constant="13" id="59z-tY-4oY"/>
                             <constraint firstItem="GWG-05-XRf" firstAttribute="centerX" secondItem="H7h-mE-sVf" secondAttribute="centerX" id="7Q8-D1-ual"/>
                             <constraint firstItem="cxr-39-KAg" firstAttribute="top" secondItem="GWG-05-XRf" secondAttribute="bottom" constant="16" id="EMN-9E-NEe"/>
                             <constraint firstAttribute="trailing" secondItem="gfp-3L-IYu" secondAttribute="trailing" id="Ese-mp-lCJ"/>
                             <constraint firstItem="GWG-05-XRf" firstAttribute="top" secondItem="gfp-3L-IYu" secondAttribute="bottom" id="FlO-oy-WiO"/>
                             <constraint firstItem="gfp-3L-IYu" firstAttribute="top" secondItem="H7h-mE-sVf" secondAttribute="top" id="Obi-WS-aaC"/>
+                            <constraint firstAttribute="trailing" secondItem="GWG-05-XRf" secondAttribute="trailing" constant="13" id="VNl-mk-nsn"/>
                             <constraint firstItem="sPz-qE-SCO" firstAttribute="width" secondItem="H7h-mE-sVf" secondAttribute="width" id="mhc-MF-jYE"/>
                         </constraints>
                     </view>
@@ -2524,10 +2536,12 @@
                             <constraint firstItem="EtV-5W-DN8" firstAttribute="leading" secondItem="6Sh-bH-aTc" secondAttribute="leading" id="PLh-Z6-IGz"/>
                             <constraint firstItem="PM3-gJ-sp4" firstAttribute="leading" secondItem="Qwd-Vq-fSZ" secondAttribute="leading" id="S4P-64-wFg"/>
                             <constraint firstItem="vc6-6e-6QN" firstAttribute="top" secondItem="PM3-gJ-sp4" secondAttribute="bottom" constant="8" id="Z2u-kv-aau"/>
+                            <constraint firstAttribute="trailing" secondItem="vc6-6e-6QN" secondAttribute="trailing" constant="13" id="eBf-8n-Ki3"/>
                             <constraint firstItem="EtV-5W-DN8" firstAttribute="top" secondItem="6Sh-bH-aTc" secondAttribute="bottom" id="iS7-7j-ARi"/>
                             <constraint firstItem="vc6-6e-6QN" firstAttribute="centerX" secondItem="Qwd-Vq-fSZ" secondAttribute="centerX" id="k14-sq-cT5"/>
                             <constraint firstItem="EtV-5W-DN8" firstAttribute="trailing" secondItem="6Sh-bH-aTc" secondAttribute="trailing" id="lyt-U8-Y90"/>
                             <constraint firstAttribute="trailing" secondItem="PM3-gJ-sp4" secondAttribute="trailing" id="ohQ-hN-Yt3"/>
+                            <constraint firstItem="vc6-6e-6QN" firstAttribute="leading" secondItem="Qwd-Vq-fSZ" secondAttribute="leading" constant="13" id="vIL-YZ-ZGj"/>
                             <constraint firstItem="6Sh-bH-aTc" firstAttribute="top" secondItem="IbA-ep-j25" secondAttribute="bottom" constant="38" id="x4v-ty-tbL"/>
                         </constraints>
                     </view>
@@ -2869,7 +2883,9 @@
                             <constraint firstItem="LjX-V3-7h1" firstAttribute="top" secondItem="7Sm-UV-6GI" secondAttribute="bottom" constant="28" id="fPs-y5-NLv"/>
                             <constraint firstAttribute="trailing" secondItem="tJl-d9-UYN" secondAttribute="trailing" constant="16" id="hBK-4L-rhN"/>
                             <constraint firstItem="LBf-qf-nKb" firstAttribute="top" secondItem="Tsm-hI-BbH" secondAttribute="bottom" constant="18" id="oBX-S9-CqS"/>
+                            <constraint firstItem="Tsm-hI-BbH" firstAttribute="leading" secondItem="qu7-VL-gc2" secondAttribute="leading" constant="13" id="red-5m-eLm"/>
                             <constraint firstAttribute="trailing" secondItem="cag-V1-dMo" secondAttribute="trailing" constant="16" id="saX-44-vbs"/>
+                            <constraint firstAttribute="trailing" secondItem="Tsm-hI-BbH" secondAttribute="trailing" constant="13" id="u27-r8-oMi"/>
                             <constraint firstItem="LjX-V3-7h1" firstAttribute="trailing" secondItem="7Sm-UV-6GI" secondAttribute="trailing" id="wox-t7-eSI"/>
                             <constraint firstItem="a0M-VO-Tuz" firstAttribute="leading" secondItem="qu7-VL-gc2" secondAttribute="leading" constant="18" id="yQK-B6-pEA"/>
                         </constraints>
@@ -2942,8 +2958,10 @@
                             <constraint firstItem="q1C-MV-4d6" firstAttribute="centerX" secondItem="CIu-n1-vi2" secondAttribute="centerX" id="bAh-yp-7xT"/>
                             <constraint firstItem="Kb8-gX-0Hw" firstAttribute="centerX" secondItem="CIu-n1-vi2" secondAttribute="centerX" id="d0g-Ir-Z5Q"/>
                             <constraint firstItem="Kb8-gX-0Hw" firstAttribute="leading" secondItem="CIu-n1-vi2" secondAttribute="leading" constant="18" id="jZr-A6-eMS"/>
+                            <constraint firstItem="q1C-MV-4d6" firstAttribute="leading" secondItem="CIu-n1-vi2" secondAttribute="leading" constant="13" id="n5o-76-38L"/>
                             <constraint firstItem="Kb8-gX-0Hw" firstAttribute="top" secondItem="CIu-n1-vi2" secondAttribute="top" constant="132" id="oNR-yc-u1b"/>
                             <constraint firstItem="o9E-qz-Sgf" firstAttribute="top" secondItem="Kb8-gX-0Hw" secondAttribute="bottom" constant="28" id="pcx-Cj-x0q"/>
+                            <constraint firstAttribute="trailing" secondItem="q1C-MV-4d6" secondAttribute="trailing" constant="13" id="ruc-Ma-LJ2"/>
                             <constraint firstItem="Kb8-gX-0Hw" firstAttribute="top" secondItem="CIu-n1-vi2" secondAttribute="top" constant="132" id="rzV-lz-H7r"/>
                             <constraint firstAttribute="trailingMargin" secondItem="Kb8-gX-0Hw" secondAttribute="trailing" constant="2" id="sP3-2S-vg5"/>
                             <constraint firstItem="Kb8-gX-0Hw" firstAttribute="leading" secondItem="CIu-n1-vi2" secondAttribute="leading" constant="18" id="sSj-sk-uYm"/>

--- a/MiracleMessages/Base.lproj/Main.storyboard
+++ b/MiracleMessages/Base.lproj/Main.storyboard
@@ -394,12 +394,11 @@
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s70-JI-P1t">
                                 <rect key="frame" x="16" y="142" width="343" height="444"/>
-                                <mutableString key="text">We would be happy to help you record a short video message to your loved one(s) and attempt to deliver it! Please be aware that, by recording a video message with us, you acknowledge that:
+                                <string key="text">We would be happy to help you record a short video message to your loved one(s) and attempt to deliver it! Please be aware that, by recording a video message with us, you acknowledge that:
 a.) your video may be made public and shared widely;
 b.) we don't know how your loved one(s) will respond, if at all; and
 c.) we don't know if we'll be able to find your loved one(s).
-                                </mutableString>
-
+                                </string>
                                 <fontDescription key="fontDescription" name="ArialMT" family="Arial" pointSize="20"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -2167,6 +2166,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                             <constraint firstItem="Hur-rx-VmS" firstAttribute="leading" secondItem="6fx-Nd-Btj" secondAttribute="leading" id="ivq-tY-hJS"/>
                             <constraint firstItem="rHV-m4-hgG" firstAttribute="trailing" secondItem="Hur-rx-VmS" secondAttribute="trailing" id="k9a-em-3I6"/>
                             <constraint firstItem="jLO-aa-829" firstAttribute="leading" secondItem="53p-ZJ-4wX" secondAttribute="leading" id="kEP-XO-8GZ"/>
+                            <constraint firstItem="pHN-Iy-dG4" firstAttribute="top" relation="greaterThanOrEqual" secondItem="jLO-aa-829" secondAttribute="bottom" constant="10" id="olB-HA-yMj"/>
                             <constraint firstItem="53p-ZJ-4wX" firstAttribute="top" secondItem="R7R-fO-Mpw" secondAttribute="bottom" constant="4" id="poj-oA-M6f"/>
                             <constraint firstItem="53p-ZJ-4wX" firstAttribute="leading" secondItem="R7R-fO-Mpw" secondAttribute="leading" id="qdT-Gk-DD7"/>
                             <constraint firstItem="6fx-Nd-Btj" firstAttribute="trailing" secondItem="VTh-Xz-h1f" secondAttribute="trailing" id="r2a-pa-J35"/>

--- a/MiracleMessages/Base.lproj/Main.storyboard
+++ b/MiracleMessages/Base.lproj/Main.storyboard
@@ -310,7 +310,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ready to record a message?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1L3-MF-TRz">
-                                <rect key="frame" x="18" y="147.5" width="328" height="92"/>
+                                <rect key="frame" x="18" y="143.5" width="328" height="92"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="328" id="2dh-Wt-jLt"/>
                                     <constraint firstAttribute="height" constant="92" id="rav-cb-N3v"/>
@@ -320,7 +320,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hi," lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4sO-gu-4o4" userLabel="Hello Label">
-                                <rect key="frame" x="18" y="105" width="339" height="42.5"/>
+                                <rect key="frame" x="18" y="101" width="339" height="42.5"/>
                                 <fontDescription key="fontDescription" name="Arial-BoldMT" family="Arial" pointSize="38"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -375,7 +375,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Before we start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="GS4-Ok-gU7">
-                                <rect key="frame" x="18" y="105" width="339" height="45"/>
+                                <rect key="frame" x="18" y="101" width="339" height="45"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="mAY-lW-l7x"/>
                                 </constraints>
@@ -384,7 +384,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A script to guide you" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gb1-KC-2gE">
-                                <rect key="frame" x="18" y="150" width="339" height="20"/>
+                                <rect key="frame" x="18" y="146" width="339" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="SWA-UG-tqC"/>
                                 </constraints>
@@ -393,7 +393,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s70-JI-P1t">
-                                <rect key="frame" x="16" y="190" width="343" height="396"/>
+                                <rect key="frame" x="16" y="186" width="343" height="400"/>
                                 <string key="text">We would be happy to help you record a short video message to your loved one(s) and attempt to deliver it! Please be aware that, by recording a video message with us, you acknowledge that:
 a.) your video may be made public and shared widely;
 b.) we don't know how your loved one(s) will respond, if at all; and
@@ -2811,7 +2811,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a0M-VO-Tuz">
-                                <rect key="frame" x="18" y="91" width="339" height="45"/>
+                                <rect key="frame" x="18" y="87" width="339" height="45"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="1Tc-Kb-pOL"/>
                                 </constraints>
@@ -2820,7 +2820,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Everything look good?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Sm-UV-6GI">
-                                <rect key="frame" x="18" y="136" width="339" height="21"/>
+                                <rect key="frame" x="18" y="132" width="339" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="ghv-qa-p67"/>
                                 </constraints>
@@ -2829,7 +2829,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Click the 'Submit' button below to upload to our database." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LjX-V3-7h1" customClass="VerticalAlignLabel" customModule="Dev_MiracleMsg" customModuleProvider="target">
-                                <rect key="frame" x="18" y="185" width="339" height="49.5"/>
+                                <rect key="frame" x="18" y="181" width="339" height="49.5"/>
                                 <fontDescription key="fontDescription" name="ArialMT" family="Arial" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -2851,7 +2851,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OR" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tJl-d9-UYN">
-                                <rect key="frame" x="16" y="259.5" width="343" height="35"/>
+                                <rect key="frame" x="16" y="255.5" width="343" height="35"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="3a5-y9-UZ3"/>
                                 </constraints>
@@ -2860,7 +2860,7 @@ c.) we don't know if we'll be able to find your loved one(s).
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Click back to retake the video." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cag-V1-dMo">
-                                <rect key="frame" x="16" y="319.5" width="343" height="60"/>
+                                <rect key="frame" x="16" y="315.5" width="343" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="fdE-Xx-Qcq"/>
                                 </constraints>

--- a/MiracleMessages/Info.plist
+++ b/MiracleMessages/Info.plist
@@ -52,7 +52,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>31</string>
+	<string>32</string>
 	<key>FIREBASE</key>
 	<string>$(FIREBASE_SERVICES_FILENAME)</string>
 	<key>Fabric</key>


### PR DESCRIPTION
Fixed overlapping of text, buttons and margins from side on multiple screens:
- Lets Get started screen
- Login Screen
- Before we start screen
- Home Screen 
- Consent screen
- Signature screen
- From screen
- To screen
- Review screen

Note: I couldn't run the application on my iPad due to provisioning profile issues, so was testing on simulators. That's why I couldn't test beyond the review screen, since I cannot record videos.